### PR TITLE
valve maintenance: make sure the valve get closed again before restarting PID (temp based maintenance)

### DIFF
--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -650,10 +650,10 @@ class AIThermostat(ClimateEntity, RestoreEntity):
             payload = json.dumps(mqtt_trv_valve, cls=JSONEncoder)
             await self.mqtt.async_publish(self.hass,'zigbee2mqtt/'+self.hass.states.get(self.heater_entity_id).attributes.get('device').get('friendlyName')+'/set', payload, 0, False)
             await asyncio.sleep(60)
-            mqtt_trv_valve = {"current_heating_setpoint": float(self._target_temp)}
+            mqtt_trv_valve = {"current_heating_setpoint": 5}
             payload = json.dumps(mqtt_trv_valve, cls=JSONEncoder)
             await self.mqtt.async_publish(self.hass,'zigbee2mqtt/'+self.hass.states.get(self.heater_entity_id).attributes.get('device').get('friendlyName')+'/set', payload, 0, False)
-            await asyncio.sleep(5)
+            await asyncio.sleep(60)
         self.ignoreStates = False
         self._async_control_heating()
 


### PR DESCRIPTION

## Motivation:

The valve gets opened to maximum and turning the thermostat back to "normal" will likely not close it again, so you end up with a fully opened valve as starting point for the PID algorithm which is likely to overheat the room.

## Changes:

Add an additional setpoint 5°C and a longer wait for the valve to close the valve fully before switching back to the normal operation.

## Related issue (check one):

  - [ ] fixes #<issue number goes here>
  - [x] there is no related issue ticket

## Checklist (check one):
  
  - [ ] I did not change any code (e.g. documentation changes)
  - [ ] The code change is tested and works locally.
  - [x] the code changes are insignificant (no testing required) 

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

  - [ ] an `info.md` is added to the device folder.
  - [ ] I avoided any changes to other device mappings
  - [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
