### PR TITLE
rename overswing to dampening

### DIFF
--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -212,7 +212,7 @@ class AIThermostat(ClimateEntity, RestoreEntity):
         self.summer = False
         self.ignoreStates = False
         self.lastCalibration = datetime.now() - timedelta(minutes = 5)
-        self.lastOverswing = datetime.now()
+        self.start_dampening_event = None
         self._device_class = device_class
         self._state_class = state_class
         self._today_nightmode_end = datetime.now()


### PR DESCRIPTION
## Motivation:

As documented in #110 the overswing functionality will be renamed to dampening

## Changes:

This PR changes the overswing function and variables to dampening

## Related issue (check one):

  - [ ] fixes #<issue number goes here>
  - [x] there is no related issue ticket

## Checklist (check one):
  
  - [ ] I did not change any code (e.g. documentation changes)
  - [ ] The code change is tested and works locally.
  - [x] This code has not been tested (as the function is currently not fully implemented)

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

  - [ ] an `info.md` is added to the device folder.
  - [ ] I avoided any changes to other device mappings
  - [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
