### PR TITLE
remove old dampening code

### DIFF
--- a/custom_components/ai_thermostat/models/utils.py
+++ b/custom_components/ai_thermostat/models/utils.py
@@ -1,8 +1,6 @@
-import asyncio
 import logging
-from datetime import datetime, timedelta
 
-from custom_components.ai_thermostat.helpers import convert_decimal, set_trv_values
+from custom_components.ai_thermostat.helpers import convert_decimal
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,22 +32,6 @@ def default_calibration(self):
 	new_calibration = float((float(self._cur_temp) - float(state.get('local_temperature'))) + float(state.get('local_temperature_calibration')))
 	return convert_decimal(new_calibration)
 
-
-async def evaluate_dampening(self, calibration):
-	state = self.hass.states.get(self.heater_entity_id).attributes
-	if (datetime.now() > (self.last_dampening_timestamp + timedelta(minutes=15))) and state.get(
-			'system_mode') is not None and self._target_temp is not None and self._cur_temp is not None and not self.night_status:
-		check_dampening = (float(self._target_temp) - 0.5) < float(self._cur_temp)
-		if check_dampening:
-			self.ignore_states = True
-			_LOGGER.debug("Dampening started")
-			await set_trv_values(self,'temperature', float(5))
-			await asyncio.sleep(60)
-			await set_trv_values(self,'temperature', float(calibration))
-			self.last_dampening_timestamp = datetime.now()
-			self.ignore_states = False
-
-
 def temperature_calibration(self):
 	state = self.hass.states.get(self.heater_entity_id).attributes
 	new_calibration = abs(float(round((float(self._target_temp) - float(self._cur_temp)) + float(state.get('local_temperature')), 2)))
@@ -57,8 +39,5 @@ def temperature_calibration(self):
 		new_calibration = float(self._min_temp)
 	if new_calibration > float(self._max_temp):
 		new_calibration = float(self._max_temp)
-	
-	#loop = asyncio.get_event_loop()
-	#loop.create_task(evaluate_dampening(self, new_calibration))
 	
 	return new_calibration


### PR DESCRIPTION
## Motivation:

Remove unused code (which is not up to quality standard)

## Changes:

Remove evaluate_dampening and needed libraries

## Related issue (check one):

- [x] fixes #134 
- [ ] there is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
