### PR TITLE
Revert "Update climate.py"

### DIFF
--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -203,7 +203,7 @@ class AIThermostat(ClimateEntity, RestoreEntity, ABC):
 		self.call_for_heat = None
 		self.ignore_states = False
 		self.last_calibration = None
-		self.last_dampening_timestamp = datetime.now()
+		self.last_dampening_timestamp = None
 		self._device_class = device_class
 		self._state_class = state_class
 		self._today_nightmode_end = datetime.now()


### PR DESCRIPTION
last_dampening_timestamp needs to be None on startup.

This reverts commit 6d9e9084f442a99dd95038480a6d9d614da33f08.

## Motivation:

The change is just wrong. There's no dampening event on startup, so why fill in the variable with nonsense? 

## Changes:

Revert this change

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
